### PR TITLE
Resolve build failure due to line spacing

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,7 +1,1 @@
-# apt packages to install should be listed one per line
-libgl1
-libglib2.0-0
-
-#
-git
-jq
+libgl1 libglib2.0-0 git jq


### PR DESCRIPTION
- Fixes #5
- This causes apt-get to fail the install because git, jq, etc are interpreted as commands rather than arguments to apt-get

Signed-off-by: Grant Curell <grant_curell@dell.com>